### PR TITLE
avdecc: fix compiler warning

### DIFF
--- a/avb-demoapps/lib/avdecc/avdecc_internal.h
+++ b/avb-demoapps/lib/avdecc/avdecc_internal.h
@@ -423,7 +423,7 @@ int setup_descriptor_data(struct device_entity *dev_e, uint8_t *mac_addr);
 /*
  * Common Utility
  */
-bool is_interface_linkup(int sock, const char *interface_name);
+int is_interface_linkup(int sock, const char *interface_name);
 
 void set_socket_nonblocking(int fd);
 

--- a/avb-demoapps/lib/avdecc/common.c
+++ b/avb-demoapps/lib/avdecc/common.c
@@ -15,7 +15,7 @@
 
 #include "avdecc_internal.h"
 
-bool is_interface_linkup(int sock, const char *interface_name)
+int is_interface_linkup(int sock, const char *interface_name)
 {
 	struct ifreq ifr;
 


### PR DESCRIPTION
adp.c:134:37: warning: comparison of constant '0' with boolean expression is always false [-Wbool-compare]
|   if (ctx->adp_state.last_link_is_up < 0) {

Error on link status request can't be detected via bool storage class.

Signed-off-by: Andreas Pape <apape@de.adit-jv.com>